### PR TITLE
ManagerWorker: default_models_query

### DIFF
--- a/spec/sidekiq/active_record/manager_worker_spec.rb
+++ b/spec/sidekiq/active_record/manager_worker_spec.rb
@@ -20,6 +20,24 @@ describe Sidekiq::ActiveRecord::ManagerWorker do
 
   let(:models_query) { User.active }
 
+  describe 'perform with default models query' do
+
+    before do
+      class UserManagerWorker < Sidekiq::ActiveRecord::ManagerWorker
+        sidekiq_delegate_task_to MockUserWorker
+        default_models_query -> { User.active }
+      end
+    end
+
+    let(:default_models_query) { User.active }
+    let(:worker_options) { {:batch_size => 300} }
+
+    it 'runs `perform_query_async` with the default models query and the specified options' do
+      expect(UserManagerWorker).to receive(:perform_query_async).with(default_models_query, worker_options)
+      UserManagerWorker.new.perform(worker_options)
+    end
+  end
+
   describe 'perform_query_async' do
 
     def run_worker(options = {})


### PR DESCRIPTION
``` ruby
class UserManagerWorker < Sidekiq::ActiveRecord::ManagerWorker
  sidekiq_delegate_task_to UserTaskWorker
  default_models_query -> { User.active }
end

UserManagerWorker.perform_async(:batch_size => 300)
```

this is a solution to: https://github.com/sidekiq-orm/sidekiq-activerecord/issues/3
@seuros /cc
