### PR TITLE
HOTFIX: TaskWorker aliases methods not called

### DIFF
--- a/spec/examples/alias_user_task_worker.rb
+++ b/spec/examples/alias_user_task_worker.rb
@@ -1,0 +1,27 @@
+module Examples
+  class AliasUserTaskWorker < Sidekiq::ActiveRecord::TaskWorker
+
+    sidekiq_task_model :user # or User class
+    sidekiq_task_options :identifier_key => :email
+
+    def perform_on_user(new_email = nil)
+      UserMailer.update_email(user, new_email)
+    end
+
+    # optional
+    def not_found_user(email)
+      Log.error "User not found for email:#{email}"
+    end
+
+    # optional
+    def should_perform_on_user?
+      user.active?
+    end
+
+    # optional
+    def did_not_perform_on_user
+      Log.error "User #{user.id} is invalid"
+    end
+
+  end
+end

--- a/spec/examples/helper_classes.rb
+++ b/spec/examples/helper_classes.rb
@@ -1,0 +1,11 @@
+module Examples
+  class UserMailer
+    def self.update_email(user, new_email)
+    end
+  end
+
+  class Log
+    def self.error(msg)
+    end
+  end
+end

--- a/spec/examples/no_alias_user_task_worker.rb
+++ b/spec/examples/no_alias_user_task_worker.rb
@@ -1,0 +1,27 @@
+module Examples
+  class NoAliasUserTaskWorker < Sidekiq::ActiveRecord::TaskWorker
+
+    sidekiq_task_model :user # or User class
+    sidekiq_task_options :identifier_key => :email
+
+    def perform_on_model(new_email = nil)
+      UserMailer.update_email(task_model, new_email)
+    end
+
+    # optional
+    def not_found_model(email)
+      Log.error "User not found for email:#{email}"
+    end
+
+    # optional
+    def should_perform_on_model?
+      user.active?
+    end
+
+    # optional
+    def did_not_perform_on_model
+      Log.error "User #{task_model.id} is invalid"
+    end
+
+  end
+end

--- a/spec/sidekiq/active_record/example/alias_user_task_worker_spec.rb
+++ b/spec/sidekiq/active_record/example/alias_user_task_worker_spec.rb
@@ -1,0 +1,86 @@
+module Examples
+  describe AliasUserTaskWorker do
+
+    let(:logger)  { Log }
+    let(:service_class)  { UserMailer }
+    let(:other_param)  { 'new@email.com' }
+
+    let(:task_worker_class)  { AliasUserTaskWorker }
+    subject(:task_worker)  { AliasUserTaskWorker.new }
+
+    def run_worker
+      task_worker.perform(user.email, other_param)
+    end
+
+    before do
+      allow(service_class).to receive(:update_email)
+      allow(logger).to receive(:error)
+    end
+
+    context 'when the user is not found' do
+
+      let(:unfound_email) { 'unfound@email.com' }
+
+      it 'calls not_found_user' do
+        expect(task_worker).to receive(:not_found_user).with(unfound_email).and_call_original
+        task_worker.perform(unfound_email)
+      end
+
+      it 'calls the logger with the not found email' do
+        task_worker.perform(unfound_email)
+        expect(logger).to have_received(:error).with("User not found for email:#{unfound_email}")
+      end
+    end
+
+    context 'when the user is found' do
+
+      let(:user) { create(:user) }
+
+      it 'calls should_perform_on_user?' do
+        expect(task_worker).to receive(:should_perform_on_user?).and_call_original
+        run_worker
+      end
+
+      it 'check if the user is active' do
+        allow(task_worker).to receive(:user).and_return(user)
+        expect(user).to receive(:active?).and_call_original
+        run_worker
+      end
+
+      context 'when the user is active' do
+
+        let(:user) { create(:user, :active) }
+
+        it 'calls perform_on_user' do
+          expect(task_worker).to receive(:perform_on_user).and_call_original
+          run_worker
+        end
+
+        it 'calls the service class with the user' do
+          run_worker
+          expect(service_class).to have_received(:update_email).with(user, other_param)
+        end
+      end
+
+      context 'when the user is inactive' do
+
+        let(:user) { create(:user, :banned) }
+
+        it 'ignores the user' do
+          run_worker
+          expect(service_class).to_not have_received(:update_email)
+        end
+
+        it 'calls did_not_perform_on_user' do
+          expect(task_worker).to receive(:did_not_perform_on_user).and_call_original
+          run_worker
+        end
+
+        it 'calls the logger with the inactive user' do
+          run_worker
+          expect(logger).to have_received(:error).with("User #{user.id} is invalid")
+        end
+      end
+    end
+  end
+end

--- a/spec/sidekiq/active_record/example/no_alias_user_task_worker_spec.rb
+++ b/spec/sidekiq/active_record/example/no_alias_user_task_worker_spec.rb
@@ -1,0 +1,86 @@
+module Examples
+  describe NoAliasUserTaskWorker do
+
+    let(:logger)  { Log }
+    let(:service_class)  { UserMailer }
+    let(:other_param)  { 'new@email.com' }
+
+    let(:task_worker_class)  { NoAliasUserTaskWorker }
+    subject(:task_worker)  { NoAliasUserTaskWorker.new }
+
+    def run_worker
+      task_worker.perform(user.email, other_param)
+    end
+
+    before do
+      allow(service_class).to receive(:update_email)
+      allow(logger).to receive(:error)
+    end
+
+    context 'when the user is not found' do
+
+      let(:unfound_email) { 'unfound@email.com' }
+
+      it 'calls not_found_model' do
+        expect(task_worker).to receive(:not_found_model).with(unfound_email).and_call_original
+        task_worker.perform(unfound_email)
+      end
+
+      it 'calls the logger with the not found email' do
+        task_worker.perform(unfound_email)
+        expect(logger).to have_received(:error).with("User not found for email:#{unfound_email}")
+      end
+    end
+
+    context 'when the user is found' do
+
+      let(:user) { create(:user) }
+
+      it 'calls should_perform_on_model?' do
+        expect(task_worker).to receive(:should_perform_on_model?).and_call_original
+        run_worker
+      end
+
+      it 'check if the user is active' do
+        allow(task_worker).to receive(:user).and_return(user)
+        expect(user).to receive(:active?).and_call_original
+        run_worker
+      end
+
+      context 'when the user is active' do
+
+        let(:user) { create(:user, :active) }
+
+        it 'calls perform_on_model' do
+          expect(task_worker).to receive(:perform_on_model).and_call_original
+          run_worker
+        end
+
+        it 'calls the service class with the user' do
+          run_worker
+          expect(service_class).to have_received(:update_email).with(user, other_param)
+        end
+      end
+
+      context 'when the user is inactive' do
+
+        let(:user) { create(:user, :banned) }
+
+        it 'ignores the user' do
+          run_worker
+          expect(service_class).to_not have_received(:update_email)
+        end
+
+        it 'calls did_not_perform_on_model' do
+          expect(task_worker).to receive(:did_not_perform_on_model).and_call_original
+          run_worker
+        end
+
+        it 'calls the logger with the inactive user' do
+          run_worker
+          expect(logger).to have_received(:error).with("User #{user.id} is invalid")
+        end
+      end
+    end
+  end
+end

--- a/spec/sidekiq/active_record/task_worker_spec.rb
+++ b/spec/sidekiq/active_record/task_worker_spec.rb
@@ -92,11 +92,6 @@ describe Sidekiq::ActiveRecord::TaskWorker do
           run_worker
           expect(task_worker.task_model).to eq user
         end
-
-        it 'has an alias of `task_model` withe for the specified model name' do
-          run_worker
-          expect(task_worker.user).to eq user
-        end
       end
 
     end
@@ -117,11 +112,6 @@ describe Sidekiq::ActiveRecord::TaskWorker do
         it 'sets the model' do
           run_worker
           expect(task_worker.task_model).to eq user
-        end
-
-        it 'has an alias of `task_model` withe for the specified model name' do
-          run_worker
-          expect(task_worker.user).to eq user
         end
       end
 
@@ -155,13 +145,6 @@ describe Sidekiq::ActiveRecord::TaskWorker do
           expect(task_worker).to_not receive(:perform_on_model)
           run_worker
         end
-
-        describe 'method alias' do
-          it 'has an alias of not_found_model hook with for the specified task model name' do
-            expect(task_worker.not_found_user(trash_id)).to eq trash_id
-          end
-        end
-
       end
 
       context 'when the mode is found' do
@@ -170,24 +153,6 @@ describe Sidekiq::ActiveRecord::TaskWorker do
           it 'calls the should_perform_on_model? hook' do
             expect(task_worker).to receive(:should_perform_on_model?)
             run_worker
-          end
-
-          describe 'method alias' do
-
-            let(:mock_result) { 1234 }
-
-            before do
-              class UserTaskWorker
-                def should_perform_on_user?
-                  1234
-                end
-              end
-            end
-
-            it 'has an alias of should_perform_on_model? hook with for the specified task model name' do
-              run_worker
-              expect(task_worker.should_perform_on_user?).to eq mock_result
-            end
           end
         end
 
@@ -216,14 +181,6 @@ describe Sidekiq::ActiveRecord::TaskWorker do
                 task_worker.perform(user.id, user.email)
               end
             end
-
-            describe 'method alias' do
-              it 'has an alias of perform_on_model hook with for the specified task model name' do
-                task_worker.perform(user.id)
-                expect(task_worker.perform_on_user).to eq user
-              end
-            end
-
           end
         end
 
@@ -242,21 +199,13 @@ describe Sidekiq::ActiveRecord::TaskWorker do
             expect(task_worker).to_not receive(:perform_on_model)
             run_worker
           end
-
-          describe 'method alias' do
-            it 'has an alias of did_not_perform_on_model hook with for the specified task model name' do
-              run_worker
-              expect(task_worker.did_not_perform_on_user).to eq user
-            end
-          end
-
         end
 
       end
     end
   end
 
-  describe 'perform_async_on', :focus do
+  describe 'perform_async_on' do
 
     before do
       class UserTaskWorker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ require 'database_cleaner'
 
 RSpec.configure do |config|
   config.alias_example_to :expect_it
+  config.filter_run_including :focus => true
+  config.run_all_when_everything_filtered = true
 end
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
-
+Dir['./spec/examples/**/*.rb'].sort.each { |f| require f }

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,4 +1,8 @@
 class User < ActiveRecord::Base
   scope :active, -> { where(:status => :active) }
   scope :banned, -> { where(:status => :banned) }
+
+  def active?
+    status.try(:to_sym) == :active
+  end
 end


### PR DESCRIPTION
@seuros aliased methods were not called, since the original methods were triggered
